### PR TITLE
lockedのdocker-composeと通信できるように修正_3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'jquery-rails', '4.3.1'
 gem 'turbolinks',   '5.0.1'
 gem 'jbuilder',     '2.7.0'
 gem 'therubyracer'
+gem 'mysql2'
 
 gem 'nokogiri'
 gem 'locked-rb', :git => "https://github.com/OnetapInc/locked-ruby.git", :branch => "fix/adopt-docker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/OnetapInc/locked-ruby.git
+  revision: fa02ba4dad91236a29a709c56d957d7e162326f2
+  branch: fix/adopt-docker
+  specs:
+    locked-rb (0.0.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -244,10 +251,10 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
+    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    locked-rb (0.0.1)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -271,6 +278,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     multi_json (1.13.1)
+    mysql2 (0.5.2)
     nenv (0.3.0)
     nio4r (2.4.0)
     nokogiri (1.10.3)
@@ -283,6 +291,14 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.4.3)
+      byebug (>= 9.0, < 9.1)
+      pry (~> 0.10)
+    pry-doc (1.0.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.9.1)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -324,6 +340,7 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.5)
       optimist (~> 3.0)
+    ref (2.0.0)
     ruby-progressbar (1.10.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -353,6 +370,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -374,6 +394,7 @@ GEM
     will_paginate (3.1.5)
     xml-simple (1.1.5)
     xmlrpc (0.3.0)
+    yard (0.9.20)
 
 PLATFORMS
   ruby
@@ -393,11 +414,15 @@ DEPENDENCIES
   jbuilder (= 2.7.0)
   jquery-rails (= 4.3.1)
   listen (= 3.0.8)
-  locked-rb
+  locked-rb!
   mini_magick (= 4.9.4)
   minitest-reporters (= 1.1.14)
+  mysql2
   nokogiri
   pg (= 0.18.4)
+  pry-byebug
+  pry-doc
+  pry-rails
   puma (= 3.9.1)
   rails (= 5.2.2)
   rails-controller-testing (= 1.0.2)
@@ -406,6 +431,7 @@ DEPENDENCIES
   spring (= 2.0.2)
   spring-watcher-listen (= 2.0.1)
   sqlite3 (= 1.3.13)
+  therubyracer
   turbolinks (= 5.0.1)
   tzinfo-data
   uglifier (= 3.2.0)
@@ -413,4 +439,4 @@ DEPENDENCIES
   will_paginate (= 3.1.5)
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,44 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
+  encoding: utf8mb4
+  charset: utf8mb4
+  collation: utf8mb4_general_ci
+  reconnect: false
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  username: <%= ENV['RAILS_DATABASE_USERNAME'] || 'lockeduser' %>
+  password: <%= ENV['RAILS_DATABASE_PASSWORD'] || 'LockedPass!0507' %>
+  host: <%= ENV['RAILS_DATABASE_HOST'] || '127.0.0.1' %>
+  database: <%= ENV['RAILS_DATABASE_NAME'] || 'locked_dev' %>
+  port: <%= ENV['RAILS_DATABASE_PORT'] || '3306' %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  username: <%= ENV['RAILS_DATABASE_USERNAME'] || 'lockeduser' %>
+  password: <%= ENV['RAILS_DATABASE_PASSWORD'] || 'LockedPass!0507' %>
+  host: <%= ENV['RAILS_DATABASE_HOST'] || '127.0.0.1' %>
+  database: <%= ENV['RAILS_DATABASE_NAME'] || 'locked_test' %>
+  port: <%= ENV['RAILS_DATABASE_PORT'] || '3306' %>
+
+staging:
+  <<: *default
+  username: <%= ENV['RAILS_DATABASE_USERNAME'] %>
+  password: <%= ENV['RAILS_DATABASE_PASSWORD'] %>
+  host: <%= ENV['RAILS_DATABASE_HOST'] %>
+  database: <%= ENV['RAILS_DATABASE_NAME'] %>
+  port: <%= ENV['DATABASE_PORT'] %>
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  username: <%= ENV['RAILS_DATABASE_USERNAME'] || 'LockedUserPro' %>
+  password: <%= ENV['RAILS_DATABASE_PASSWORD'] || 'Kp1JBF3VadE3q!' %>
+  host: <%= ENV['RAILS_DATABASE_HOST'] || 'localhost' %>
+  database: <%= ENV['RAILS_DATABASE_NAME'] || 'locked_prod' %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,9 +12,9 @@
 
 ActiveRecord::Schema.define(version: 2019_07_14_000000) do
 
-  create_table "microposts", force: :cascade do |t|
+  create_table "microposts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "content"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "picture"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2019_07_14_000000) do
     t.index ["user_id"], name: "index_microposts_on_user_id"
   end
 
-  create_table "relationships", force: :cascade do |t|
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "follower_id"
     t.integer "followed_id"
     t.datetime "created_at", null: false
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2019_07_14_000000) do
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false
@@ -50,4 +50,5 @@ ActiveRecord::Schema.define(version: 2019_07_14_000000) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "microposts", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       RAILS_DATABASE_PASSWORD: root
       RAILS_DATABASE_HOST: mysqld
       RAILS_DATABASE_NAME: locked_dev
-      RAILS_DATABASE_PORT: 3307
+      RAILS_DATABASE_PORT: 3306
       BUNDLE_PATH: /app/vendor/bundle
       DOCKER_USE: 1
       LOCKED_RUBY_DEV_MODE: 'on'
@@ -35,7 +35,7 @@ services:
       MYSQL_DATABASE: 'locked_dev'
       MYSQL_ROOT_PASSWORD: 'root'
     ports:
-      - "${HOST_PORT_MYSQL}:3307"
+      - "${HOST_PORT_MYSQL}:3306"
     volumes:
       - mysqld-volume:/var/lib/mysql
 


### PR DESCRIPTION
close #17 

### 認識
.envに書いてある

```
HOST_PORT_MYSQL=33079
```

がホストで開けるポート。
docker-composeで指定している、

```
"${HOST_PORT_MYSQL}:3306"
```

によって、33079を開くとdockerの3306に繋がる。（ポートバインディング？）
結果、mysqlがデフォルトで開いているポート3306を開けるはず

なのに、sequel proで33079を開いても、テーブルがない。DBはある。（rails db:migrate:reset済みj）