### PR TITLE
ログイン確認メールを修正する 

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,6 +26,9 @@ class SessionsController < ApplicationController
   # POST /login
   def create
     user = User.find_by(email: params[:session][:email])
+    ################################
+    # 診断モードでは下記をコメントアウト
+    #################################
     if user && user.authenticate(params[:session][:password])
       if user.activated?
         # Success
@@ -34,7 +37,7 @@ class SessionsController < ApplicationController
           result = locked.authenticate(
             event: '$login.attempt',
             user_id: "user#{user.id}",
-            user_ip: request.remote_ip,
+            user_ip: request.remote_ip, # localhostのipaddressで不具合があるときは固定値を設定する '223.218.185.134'
             user_agent: request.user_agent,
             email: user.email,
             callback_url: 'https://rails-locked-sample.herokuapp.com/load'
@@ -50,9 +53,15 @@ class SessionsController < ApplicationController
           redirect_to login_url
         when 'allow'
           p 'allowです'
+    ################################
+    # 診断モードでは上記をコメントアウト
+    #################################
           log_in user
           params[:session][:remember_me] == '1' ? remember(user) : forget(user)
           redirect_back_or user
+    ################################
+    # 診断モードでは下記をコメントアウト
+    #################################
         when 'verify'
           p 'verifyです'
           user.update!(
@@ -77,6 +86,9 @@ class SessionsController < ApplicationController
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'
     end
+    ################################
+    # 診断モードでは上記をコメントアウト
+    #################################
   end
 
   # DELETE /logout

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -45,6 +45,9 @@ class SessionsController < ApplicationController
         case result[:data][:action]
         when 'none'
           p '診断モードです'
+          message = '認証モードにしてください。診断モードでは利用できません。'
+          flash[:warning] = message
+          redirect_to login_url
         when 'allow'
           p 'allowです'
           log_in user

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,16 +23,4 @@
       <%= debug(params) if Rails.env.development? %>
     </div>
   </body>
-  <script>
-    // 秘匿モード
-    let cli = new Locked({clientKey: '25256ae4475650c4fac4d5fe8782',signature: '<%= OpenSSL::HMAC.hexdigest('sha256', '25256ae4475650c4fac4d5fe8782', '318ab6c85800c0a214f3bb2e4cce5d6f') %>'})
-    cli.monitor({email: 'kajirikajiri@gmail.com', userId: '12345678'})
-
-    // 一行実装
-    // let cli = new Locked({clientKey: '25256ae4475650c4fac4d5fe8782',signature: '<%= OpenSSL::HMAC.hexdigest('sha256', '25256ae4475650c4fac4d5fe8782', '318ab6c85800c0a214f3bb2e4cce5d6f') %>'})
-    // cli.monitor({
-    //   email: '<%= encrypt('kajirikajiri@gmail.com', '318ab6c85800c0a214f3bb2e4cce5d6f') %>',
-    //   userId: '12345678'
-    //   })
-  </script>
 </html>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,9 +23,12 @@
     <% end %>
   </div>
 </div>
-<%# 診断モード %>
+<%# 診断モードではコメントアウトを解除 %>
 <%# <%= javascript_tag do %> %>
-    <%# let cli = new Locked({clientKey: 'a03a89573a21976c43c98e3b8a81',signature: '<%= OpenSSL::HMAC.hexdigest('sha256', 'a03a89573a21976c43c98e3b8a81', '10073bcf6d232e86f74cfb42051df12c') %>'}) %>
+    <%# let cli = new Locked({ %>
+      <%# clientKey: 'a03a89573a21976c43c98e3b8a81', %>
+      <%# signature: '<%= OpenSSL::HMAC.hexdigest('sha256', 'a03a89573a21976c43c98e3b8a81', '10073bcf6d232e86f74cfb42051df12c') %>' %>
+    <%# }) %>
     <%# cli.monitor({email: '<%= encrypt(@user.email, '10073bcf6d232e86f74cfb42051df12c') %>', userId: '<%= @user.id%>'}) %>
 <%# <% end %> %>
-<%# 診断モード %>
+<%# 診断モードではコメントアウトを解除 %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,11 +24,11 @@
   </div>
 </div>
 <%# 診断モードではコメントアウトを解除 %>
-<%# <%= javascript_tag do %> %>
-    <%# let cli = new Locked({ %>
-      <%# clientKey: 'a03a89573a21976c43c98e3b8a81', %>
-      <%# signature: '<%= OpenSSL::HMAC.hexdigest('sha256', 'a03a89573a21976c43c98e3b8a81', '10073bcf6d232e86f74cfb42051df12c') %>' %>
-    <%# }) %>
-    <%# cli.monitor({email: '<%= encrypt(@user.email, '10073bcf6d232e86f74cfb42051df12c') %>', userId: '<%= @user.id%>'}) %>
-<%# <% end %> %>
+<%= javascript_tag do %>
+    let cli = new Locked({
+      clientKey: 'a03a89573a21976c43c98e3b8a81',
+      signature: '<%= OpenSSL::HMAC.hexdigest('sha256', 'a03a89573a21976c43c98e3b8a81', '10073bcf6d232e86f74cfb42051df12c') %>'
+    })
+    cli.monitor({email: '<%= encrypt(@user.email, '10073bcf6d232e86f74cfb42051df12c') %>', userId: '<%= @user.id%>'})
+<% end %>
 <%# 診断モードではコメントアウトを解除 %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,3 +23,9 @@
     <% end %>
   </div>
 </div>
+<%# 診断モード %>
+<%# <%= javascript_tag do %> %>
+    <%# let cli = new Locked({clientKey: 'a03a89573a21976c43c98e3b8a81',signature: '<%= OpenSSL::HMAC.hexdigest('sha256', 'a03a89573a21976c43c98e3b8a81', '10073bcf6d232e86f74cfb42051df12c') %>'}) %>
+    <%# cli.monitor({email: '<%= encrypt(@user.email, '10073bcf6d232e86f74cfb42051df12c') %>', userId: '<%= @user.id%>'}) %>
+<%# <% end %> %>
+<%# 診断モード %>

--- a/config/initializers/locked-rb.rb
+++ b/config/initializers/locked-rb.rb
@@ -1,12 +1,12 @@
 Locked.configure do |config|
   # Same as setting it through Locked.api_key
-  config.api_key = 'e559c34e8a61c29de73a2ae3706f' #各自で変更
+  config.api_key = 'f4756e0012bd224fda41d178b217' #各自で変更
 
   # For authenticate method you can set failover strategies: deny (default), allow, verify, throw
   config.failover_strategy = :deny
 
   # Locked::RequestError is raised when timing out in milliseconds (default: 1000 milliseconds)
-  config.request_timeout = 2000
+  config.request_timeout = 10000
 
   # Whitelisted and Blacklisted headers are case insensitive and allow to use _ and - as a separator, http prefixes are removed
   # Whitelisted headers

--- a/config/initializers/locked-rb.rb
+++ b/config/initializers/locked-rb.rb
@@ -1,6 +1,6 @@
 Locked.configure do |config|
   # Same as setting it through Locked.api_key
-  config.api_key = 'f4756e0012bd224fda41d178b217' #各自で変更
+  config.api_key = 'e559c34e8a61c29de73a2ae3706f' #各自で変更
 
   # For authenticate method you can set failover strategies: deny (default), allow, verify, throw
   config.failover_strategy = :deny


### PR DESCRIPTION
関連URL
* https://github.com/OnetapInc/locked/issues/398
* https://github.com/OnetapInc/locked-api/pull/32
* https://github.com/OnetapInc/locked-frontend/pull/30
* https://github.com/OnetapInc/locked-rails-web-sample/pull/29

milestone
https://github.com/OnetapInc/locked/issues/443

## 概要
本来の診断モードを実装する

## 詳細
診断モードはログイン完了していないと実行されないが、実行されるようになっていた。
本来の機能を確認できないので修正しました。